### PR TITLE
feat: remove username from user model

### DIFF
--- a/server/src/common/utils/jwtUtils.js
+++ b/server/src/common/utils/jwtUtils.js
@@ -30,5 +30,5 @@ export const createToken = (type, subject, options = {}) => {
 export const createUserToken = (user, options = {}) => {
   // Liste des champs propres à l'utilisateur à ajouter au payload du token
   const payload = { role: user.role, nom_etablissement: user.nom_etablissement || null };
-  return createToken("user", user.username, { payload, ...options });
+  return createToken("user", user.email, { payload, ...options });
 };

--- a/server/src/factory/usersFactory.js
+++ b/server/src/factory/usersFactory.js
@@ -11,7 +11,6 @@ export class UsersFactory extends BaseFactory {
    */
   static create(props) {
     const schema = Joi.object({
-      username: Joi.string().required(),
       email: Joi.string().email().required(),
       password: Joi.string().required(),
       role: Joi.string()

--- a/server/src/http/routes/login.route.js
+++ b/server/src/http/routes/login.route.js
@@ -9,13 +9,17 @@ export default ({ users, userEvents }) => {
   router.post(
     "/",
     tryCatch(async (req, res) => {
-      const { username, password } = req.body;
-      const authenticatedUser = await users.authenticate(username, password);
+      const { email, password } = req.body;
+      const authenticatedUser = await users.authenticate(email, password);
 
       if (!authenticatedUser) return res.status(401).send();
 
       const token = createUserToken(authenticatedUser);
-      await userEvents.createUserEvent({ username, type: USER_EVENTS_TYPES.POST, action: USER_EVENTS_ACTIONS.LOGIN });
+      await userEvents.createUserEvent({
+        username: email,
+        type: USER_EVENTS_TYPES.POST,
+        action: USER_EVENTS_ACTIONS.LOGIN,
+      });
 
       return res.json({ access_token: token });
     })

--- a/server/src/http/routes/update-password.route.js
+++ b/server/src/http/routes/update-password.route.js
@@ -20,7 +20,7 @@ export default ({ users, userEvents }) => {
         const updatedUser = await users.updatePassword(req.body.token, req.body.newPassword);
 
         await userEvents.createUserEvent({
-          username: updatedUser.username,
+          username: updatedUser.email,
           type: USER_EVENTS_TYPES.POST,
           action: USER_EVENTS_ACTIONS.UPDATE_PASSWORD,
         });

--- a/server/src/http/routes/users.route.js
+++ b/server/src/http/routes/users.route.js
@@ -18,7 +18,7 @@ export default ({ users, userEvents }) => {
       const usersMapped = allUsers.map(toUserApiOutput);
 
       await userEvents.createUserEvent({
-        username: user.username,
+        username: user.email,
         type: USER_EVENTS_TYPES.GET,
         action: USER_EVENTS_ACTIONS.USERS.GET_ALL,
       });
@@ -30,7 +30,7 @@ export default ({ users, userEvents }) => {
   router.post(
     "/generate-update-password-url",
     tryCatch(async (req, res) => {
-      const passwordUpdateToken = await users.generatePasswordUpdateToken(req.body.username);
+      const passwordUpdateToken = await users.generatePasswordUpdateToken(req.body.email);
       const passwordUpdateUrl = `${config.publicUrl}/modifier-mot-de-passe?token=${passwordUpdateToken}`;
 
       return res.json({ passwordUpdateUrl });

--- a/server/src/jobs/cli.js
+++ b/server/src/jobs/cli.js
@@ -36,12 +36,11 @@ cli
 cli
   .command("create-user")
   .description("Création d'utilisateur")
-  .requiredOption("-u, --username <string>", "Username de l'utilisateur à créer")
   .requiredOption("-e, --email <string>", "Email de l'utilisateur à créer")
   .requiredOption("-r, --role <string>", "Role de l'utilisateur à créer")
-  .action(({ username, email, role }) => {
+  .action(({ email, role }) => {
     runScript(async ({ users }) => {
-      return runCreateUser(users, { username, email, role });
+      return runCreateUser(users, { email, role });
     }, JOB_NAMES.createUser);
   });
 
@@ -51,10 +50,10 @@ cli
 cli
   .command("generate-password-update-token")
   .description("Génération du lien de MAJ de mot de passe")
-  .requiredOption("-u, --username <string>", "Username de l'utilisateur à créer")
-  .action(({ username }) => {
+  .requiredOption("-e, --email <string>", "Email de l'utilisateur à créer")
+  .action(({ email }) => {
     runScript(async ({ users }) => {
-      return runGeneratePasswordUpdateToken(users, { username });
+      return runGeneratePasswordUpdateToken(users, { email });
     }, JOB_NAMES.generatePasswordUpdateToken);
   });
 

--- a/server/src/jobs/users/create/index.js
+++ b/server/src/jobs/users/create/index.js
@@ -1,13 +1,13 @@
 import { logger } from "../../../common/logger/logger.js";
 import { ROLES } from "../../../common/constants/roles.js";
 
-export const runCreateUser = async (users, { username, email, role }) => {
-  logger.info(`Will create user ${username} with email ${email} and role ${role} `);
+export const runCreateUser = async (users, { email, role }) => {
+  logger.info(`Will create user ${email} and role ${role} `);
 
   if (!Object.values(ROLES).some((item) => item === role)) {
     throw new Error(`Role ${role} doesn't exists !`);
   }
 
-  await users.createUser({ username, email, role });
-  logger.info(`User ${username} successfully created with role ${role}`);
+  await users.createUser({ email, role });
+  logger.info(`User ${email} successfully created with role ${role}`);
 };

--- a/server/src/jobs/users/generate-password-update-token/index.js
+++ b/server/src/jobs/users/generate-password-update-token/index.js
@@ -1,10 +1,10 @@
 import { logger } from "../../../common/logger/logger.js";
 
-export const runGeneratePasswordUpdateToken = async (users, { username }) => {
-  logger.info(`Will create password update token for user ${username}`);
+export const runGeneratePasswordUpdateToken = async (users, { email }) => {
+  logger.info(`Will create password update token for user ${email}`);
 
-  const token = await users.generatePasswordUpdateToken(username);
+  const token = await users.generatePasswordUpdateToken(email);
 
-  logger.info(`Password update token for user ${username} successfully created -> ${token}`);
+  logger.info(`Password update token for user ${email} successfully created -> ${token}`);
   logger.info(`Password update link -> ${users.getUpdatePasswordLink(token)}`);
 };

--- a/server/src/model/api/userApiMapper.js
+++ b/server/src/model/api/userApiMapper.js
@@ -4,7 +4,6 @@
 
 export const toUserApiOutput = (user) => ({
   id: user._id,
-  username: user.username,
   email: user.email,
   role: user.role,
   nom: user.nom,

--- a/server/src/model/collections/userSchema.js
+++ b/server/src/model/collections/userSchema.js
@@ -3,17 +3,13 @@ import { arrayOf, date, object, objectId, string } from "./jsonSchema/jsonSchema
 export const name = "users";
 
 export const indexes = () => {
-  return [
-    [{ username: 1 }, { name: "username", unique: true }],
-    [{ email: 1 }, { name: "email", unique: true }],
-  ];
+  return [[{ email: 1 }, { name: "email", unique: true }]];
 };
 
 export const schema = () => {
   return object(
     {
       _id: objectId(),
-      username: string(),
       email: string(),
       password: string(),
       password_update_token: string(),
@@ -31,8 +27,8 @@ export const schema = () => {
       updated_at: date(),
       created_at: date(),
     },
-    { required: ["username", "email", "role", "created_at"] },
-    { uniqueItems: ["username", "email"] }
+    { required: ["email", "role", "created_at"] },
+    { uniqueItems: ["email"] }
   );
 };
 

--- a/server/tests/integration/common/utils/jwtUtils.test.js
+++ b/server/tests/integration/common/utils/jwtUtils.test.js
@@ -52,12 +52,12 @@ describe("createToken", () => {
 describe("createUserToken", () => {
   it("crée un token pour un utilisateur valide avec le bon JWT_SECRET", () => {
     const testRole = "testRole";
-    const testUsername = "testUsername";
+    const testEmail = "testEmail@test.fr";
     const testEtablissement = "testEtablissement";
 
     const user = {
       role: testRole,
-      username: testUsername,
+      email: testEmail,
       nom_etablissement: testEtablissement,
     };
 
@@ -66,7 +66,7 @@ describe("createUserToken", () => {
     const decoded = jwt.verify(token, config.auth.user.jwtSecret);
     assert.ok(decoded.iat);
     assert.ok(decoded.exp);
-    assert.equal(decoded.sub === testUsername, true);
+    assert.equal(decoded.sub === testEmail, true);
     assert.equal(decoded.iss === config.appName, true);
     assert.equal(decoded.role === testRole, true);
     assert.equal(decoded.nom_etablissement === testEtablissement, true);
@@ -74,12 +74,12 @@ describe("createUserToken", () => {
 
   it("ne crée pas un token pour un utilisateur valide si le JWT_SECRET n'est pas bon", () => {
     const testRole = "testRole";
-    const testUsername = "testUsername";
+    const testEmail = "testEmail@test.fr";
     const testEtablissement = "testEtablissement";
 
     const user = {
       role: testRole,
-      username: testUsername,
+      email: testEmail,
       nom_etablissement: testEtablissement,
     };
 

--- a/server/tests/integration/db/indexes/usersIndexes.test.js
+++ b/server/tests/integration/db/indexes/usersIndexes.test.js
@@ -31,14 +31,6 @@ describe("Users Indexes", () => {
     );
   });
 
-  it("Vérifie l'existence d'un index unique sur le champ username", async () => {
-    assert.equal(
-      usersIndexes.some((item) => item.name === "username"),
-      true
-    );
-    assert.equal(usersIndexes.find((item) => item.name === "username")?.unique, true);
-  });
-
   it("Vérifie l'existence d'un index unique sur le champ email", async () => {
     assert.equal(
       usersIndexes.some((item) => item.name === "email"),

--- a/server/tests/integration/factory/userEventsFactory.test.js
+++ b/server/tests/integration/factory/userEventsFactory.test.js
@@ -4,9 +4,13 @@ import { UserEventsFactory } from "../../../src/factory/userEventsFactory.js";
 describe("Factory UserEvents", () => {
   describe("create", () => {
     it("Vérifie la création d'userEvent via sa factory", async () => {
-      const entity = await UserEventsFactory.create({ username: "testUser", type: "any", data: { hello: "world" } });
+      const entity = await UserEventsFactory.create({
+        username: "testUser@test.fr",
+        type: "any",
+        data: { hello: "world" },
+      });
 
-      assert.equal(entity.username === "testUser", true);
+      assert.equal(entity.username === "testUser@test.fr", true);
       assert.equal(entity.type === "any", true);
       assert.deepEqual(entity.data, { hello: "world" });
       assert.equal(entity.created_at !== null, true);

--- a/server/tests/integration/factory/usersFactory.test.js
+++ b/server/tests/integration/factory/usersFactory.test.js
@@ -6,19 +6,16 @@ import { UsersFactory } from "../../../src/factory/usersFactory.js";
 describe("Factory Users", () => {
   describe("create", () => {
     it("Vérifie la création d'user via sa factory avec uniquement les champs obligatoires fournis", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
       });
 
-      assert.equal(entity.username === testUsername, true);
       assert.equal(entity.email === testEmail, true);
       assert.equal(entity.role === testRole, true);
       assert.equal(entity.created_at !== null, true);
@@ -26,7 +23,6 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la création d'user via sa factory avec tous les champs obligatoires et optionnels fournis", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
@@ -38,7 +34,6 @@ describe("Factory Users", () => {
       const testNom_etablissement = "nom_etablissement";
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -50,7 +45,6 @@ describe("Factory Users", () => {
         nom_etablissement: testNom_etablissement,
       });
 
-      assert.equal(entity.username === testUsername, true);
       assert.equal(entity.email === testEmail, true);
       assert.equal(entity.role === testRole, true);
       assert.equal(entity.nom === testNom, true);
@@ -63,27 +57,11 @@ describe("Factory Users", () => {
       assert.equal(entity.updated_at === null, true);
     });
 
-    it("Vérifie la non création d'user via sa factory si aucun username fourni", async () => {
-      const testEmail = "user@email.fr";
-      const testPassword = generateRandomAlphanumericPhrase(80);
-      const testRole = ROLES.CFA;
-
-      const entity = await UsersFactory.create({
-        email: testEmail,
-        password: testPassword,
-        role: testRole,
-      });
-
-      assert.equal(entity === null, true);
-    });
-
     it("Vérifie la non création d'user via sa factory si aucun email fourni", async () => {
-      const testUsername = "user";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         password: testPassword,
         role: testRole,
       });
@@ -92,12 +70,10 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si aucun password fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         role: testRole,
       });
@@ -106,43 +82,23 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si aucun role fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
-      });
-
-      assert.equal(entity === null, true);
-    });
-
-    it("Vérifie la non création d'user via sa factory si un username au mauvais format est fourni", async () => {
-      const testUsername = 123;
-      const testEmail = "user@email.fr";
-      const testRole = ROLES.CFA;
-      const testPassword = generateRandomAlphanumericPhrase(80);
-
-      const entity = await UsersFactory.create({
-        username: testUsername,
-        email: testEmail,
-        password: testPassword,
-        role: testRole,
       });
 
       assert.equal(entity === null, true);
     });
 
     it("Vérifie la non création d'user via sa factory si un email au mauvais format est fourni", async () => {
-      const testUsername = 123;
       const testEmail = "useremail.fr";
       const testRole = ROLES.CFA;
       const testPassword = generateRandomAlphanumericPhrase(80);
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -152,13 +108,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si un password au mauvais format est fourni", async () => {
-      const testUsername = 123;
       const testEmail = "useremail.fr";
       const testRole = ROLES.CFA;
       const testPassword = 123;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -168,13 +122,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si un mauvais role fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const mauvaisRole = "mauvaisRole";
       const testPassword = generateRandomAlphanumericPhrase(80);
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: mauvaisRole,
@@ -184,13 +136,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si un nom au mauvais format est fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -201,13 +151,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si un prenom au mauvais format est fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -218,13 +166,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si une fonction au mauvais format est fournie", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -235,13 +181,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si un telephone au mauvais format est fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -252,13 +196,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si une liste d'outils_gestion au mauvais format est fournie", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,
@@ -269,13 +211,11 @@ describe("Factory Users", () => {
     });
 
     it("Vérifie la non création d'user via sa factory si un nom_etablissement au mauvais format est fourni", async () => {
-      const testUsername = "user";
       const testEmail = "user@email.fr";
       const testPassword = generateRandomAlphanumericPhrase(80);
       const testRole = ROLES.CFA;
 
       const entity = await UsersFactory.create({
-        username: testUsername,
         email: testEmail,
         password: testPassword,
         role: testRole,

--- a/server/tests/integration/http/login.route.test.js
+++ b/server/tests/integration/http/login.route.test.js
@@ -17,7 +17,7 @@ describe("API Route Login", () => {
     });
 
     const response = await httpClient.post("/api/login", {
-      username: userEmail,
+      email: userEmail,
       password: "password",
     });
 
@@ -42,7 +42,7 @@ describe("API Route Login", () => {
     });
 
     const response = await httpClient.post("/api/login", {
-      username: userEmail,
+      email: userEmail,
       password: "password",
     });
 
@@ -65,7 +65,7 @@ describe("API Route Login", () => {
     });
 
     const response = await httpClient.post("/api/login", {
-      username: "user@test.fr",
+      email: "user@test.fr",
       password: "INVALID",
     });
 
@@ -82,7 +82,7 @@ describe("API Route Login", () => {
     });
 
     const response = await httpClient.post("/api/login", {
-      username: "INVALID",
+      email: "INVALID",
       password: "password",
     });
 

--- a/server/tests/integration/http/users.route.test.js
+++ b/server/tests/integration/http/users.route.test.js
@@ -55,14 +55,12 @@ describe("API Route Login", () => {
       // Premier utilisateur : celui connecté
       assert.ok(response.data[0].id);
       assert.equal(response.data[0].password, undefined);
-      assert.equal(response.data[0].username, "user@test.fr");
       assert.equal(response.data[0].email, "user@test.fr");
       assert.equal(response.data[0].role, ROLES.ADMINISTRATOR);
 
       // Utilisateur 1
       assert.ok(response.data[1].id);
       assert.equal(response.data[1].password, undefined);
-      assert.equal(response.data[1].username, "test1@mail.com");
       assert.equal(response.data[1].email, "test1@mail.com");
       assert.equal(response.data[1].role, ROLES.CFA);
       assert.equal(response.data[1].nom, "NOM1");
@@ -75,7 +73,6 @@ describe("API Route Login", () => {
       // Utilisateur 1
       assert.ok(response.data[2].id);
       assert.equal(response.data[2].password, undefined);
-      assert.equal(response.data[2].username, "test2@mail.com");
       assert.equal(response.data[2].email, "test2@mail.com");
       assert.equal(response.data[2].role, ROLES.CFA);
       assert.equal(response.data[2].nom, "NOM2");
@@ -101,7 +98,7 @@ describe("API Route Login", () => {
 
       const response = await httpClient.post(
         "/api/users/generate-update-password-url",
-        { username: "john-doe" },
+        { email: "admin@test.fr" },
         { headers: bearerToken }
       );
 
@@ -115,13 +112,12 @@ describe("API Route Login", () => {
       // Création du user
       await services.users.createUser({
         email: "user@test.fr",
-        username: "user@test.fr",
         role: ROLES.ADMINISTRATOR,
       });
 
       const response = await httpClient.post(
         "/api/users/generate-update-password-url",
-        { username: "user@test.fr" },
+        { email: "user@test.fr" },
         { headers: bearerToken }
       );
 
@@ -162,42 +158,12 @@ describe("API Route Login", () => {
       assert.deepEqual(response.data, []);
     });
 
-    it("sends a 200 HTTP response with results when match on username", async () => {
-      const { httpClient, services, createAndLogUser } = await startServer();
-      const bearerToken = await createAndLogUser("user1@test.fr", "password", ROLES.ADMINISTRATOR);
-
-      await services.users.createUser({
-        email: "user2@test.fr",
-        username: "user2@test.fr",
-        password: "password",
-        nom_etablissement: "nom2",
-        role: ROLES.CFA,
-      });
-
-      await services.users.createUser({
-        email: "user3@test.fr",
-        username: "user3@test.fr",
-        password: "password",
-        nom_etablissement: "nom3",
-        role: ROLES.CFA,
-      });
-
-      const response = await httpClient.post("/api/users/search", { searchTerm: "user" }, { headers: bearerToken });
-
-      assert.strictEqual(response.status, 200);
-      assert.strictEqual(response.data.length, 3);
-      assert.deepEqual(response.data[0].username, "user1@test.fr");
-      assert.deepEqual(response.data[1].username, "user2@test.fr");
-      assert.deepEqual(response.data[2].username, "user3@test.fr");
-    });
-
     it("sends a 200 HTTP response with results when match on email", async () => {
       const { httpClient, services, createAndLogUser } = await startServer();
       const bearerToken = await createAndLogUser("user1@test.fr", "password", ROLES.ADMINISTRATOR);
 
       await services.users.createUser({
         email: "user2@test.fr",
-        username: "user2@test.fr",
         password: "password",
         nom_etablissement: "nom2",
         role: ROLES.CFA,
@@ -205,7 +171,6 @@ describe("API Route Login", () => {
 
       await services.users.createUser({
         email: "user3@test.fr",
-        username: "user3@test.fr",
         password: "password",
         nom_etablissement: "nom3",
         role: ROLES.CFA,
@@ -215,9 +180,9 @@ describe("API Route Login", () => {
 
       assert.strictEqual(response.status, 200);
       assert.strictEqual(response.data.length, 3);
-      assert.deepEqual(response.data[0].username, "user1@test.fr");
-      assert.deepEqual(response.data[1].username, "user2@test.fr");
-      assert.deepEqual(response.data[2].username, "user3@test.fr");
+      assert.deepEqual(response.data[0].email, "user1@test.fr");
+      assert.deepEqual(response.data[1].email, "user2@test.fr");
+      assert.deepEqual(response.data[2].email, "user3@test.fr");
     });
 
     it("sends a 200 HTTP response with results when match on organisme", async () => {
@@ -226,7 +191,6 @@ describe("API Route Login", () => {
 
       await services.users.createUser({
         email: "user2@test.fr",
-        username: "user2@test.fr",
         password: "password",
         nom_etablissement: "nom2",
         role: ROLES.CFA,
@@ -234,7 +198,6 @@ describe("API Route Login", () => {
 
       await services.users.createUser({
         email: "user3@test.fr",
-        username: "user3@test.fr",
         password: "password",
         nom_etablissement: "nom3",
         role: ROLES.CFA,
@@ -244,8 +207,8 @@ describe("API Route Login", () => {
 
       assert.strictEqual(response.status, 200);
       assert.strictEqual(response.data.length, 2);
-      assert.deepEqual(response.data[0].username, "user2@test.fr");
-      assert.deepEqual(response.data[1].username, "user3@test.fr");
+      assert.deepEqual(response.data[0].email, "user2@test.fr");
+      assert.deepEqual(response.data[1].email, "user3@test.fr");
     });
   });
 });

--- a/server/tests/integration/services/userEventsService.test.js
+++ b/server/tests/integration/services/userEventsService.test.js
@@ -8,12 +8,12 @@ describe("Service UserEvents", () => {
     it("Permet de créer un userEvent et de le sauver en base", async () => {
       const { createUserEvent } = userEventsService();
 
-      await createUserEvent({ username: "testUser", type: "any", data: { hello: "world" } });
-      const foundInDb = await dbCollection(COLLECTIONS_NAMES.UserEvents).findOne({ username: "testUser" });
+      await createUserEvent({ username: "testUser@test.fr", type: "any", data: { hello: "world" } });
+      const foundInDb = await dbCollection(COLLECTIONS_NAMES.UserEvents).findOne({ username: "testUser@test.fr" });
 
       assert.ok(foundInDb);
 
-      assert.equal(foundInDb.username === "testUser", true);
+      assert.equal(foundInDb.username === "testUser@test.fr", true);
       assert.equal(foundInDb.type === "any", true);
       assert.deepEqual(foundInDb.data, { hello: "world" });
       assert.equal(foundInDb.created_at !== null, true);

--- a/server/tests/utils/testUtils.js
+++ b/server/tests/utils/testUtils.js
@@ -14,10 +14,7 @@ export const startServer = async () => {
   const createAndLogUser = async (email, password, role, options) => {
     await services.users.createUser({ email, password, role, ...options });
 
-    const response = await httpClient.post("/api/login", {
-      username: email,
-      password: password,
-    });
+    const response = await httpClient.post("/api/login", { email, password });
 
     return {
       Authorization: "Bearer " + response.data.access_token,

--- a/ui/src/common/hooks/useUsersSearch.js
+++ b/ui/src/common/hooks/useUsersSearch.js
@@ -44,19 +44,9 @@ const useUsersSearch = (searchTerm) => {
 
   return {
     data: sortedData?.map(
-      ({
-        id,
-        username,
-        email,
-        role,
-        nom_etablissement,
-        created_at,
-        password_updated_at,
-        password_updated_token_at,
-      }) => {
+      ({ id, email, role, nom_etablissement, created_at, password_updated_at, password_updated_token_at }) => {
         return {
           id,
-          username,
           email,
           role,
           nom_etablissement,

--- a/ui/src/pages/admin/gestion-utilisateurs/UsersTable.js
+++ b/ui/src/pages/admin/gestion-utilisateurs/UsersTable.js
@@ -84,7 +84,7 @@ const UsersTable = ({ users }) => {
                     Action
                   </MenuButton>
                   <MenuList>
-                    <GetUpdatePasswordUrlMenuItem username={user.username} />
+                    <GetUpdatePasswordUrlMenuItem email={user.email} />
                   </MenuList>
                 </Menu>
               </Td>

--- a/ui/src/pages/admin/gestion-utilisateurs/UsersTable.js
+++ b/ui/src/pages/admin/gestion-utilisateurs/UsersTable.js
@@ -37,7 +37,6 @@ const UsersTable = ({ users }) => {
       </TableCaption>
       <Thead>
         <Tr background="galt">
-          <Th>Nom d&apos;utilisateur</Th>
           <Th>Email</Th>
           <Th>Role</Th>
           <Th>Nom établissement</Th>
@@ -50,7 +49,6 @@ const UsersTable = ({ users }) => {
         {itemsSliced?.map((user) => {
           return (
             <Tr key={user.id}>
-              <Td color="bluefrance">{user.username}</Td>
               <Td color="grey.800">{user.email}</Td>
               <Td color="grey.800">{user.role}</Td>
               <Td color="grey.800">{user.nom_etablissement}</Td>

--- a/ui/src/pages/admin/gestion-utilisateurs/menuItems/GetUpdatePasswordUrlMenuItem.js
+++ b/ui/src/pages/admin/gestion-utilisateurs/menuItems/GetUpdatePasswordUrlMenuItem.js
@@ -5,11 +5,11 @@ import { useMutation } from "react-query";
 
 import { postGetUserUpdatePasswordUrl } from "../../../../common/api/api.js";
 
-const GetUpdatePasswordUrlMenuItem = ({ username }) => {
+const GetUpdatePasswordUrlMenuItem = ({ email }) => {
   const toast = useToast();
   const { data, mutate } = useMutation(
     () => {
-      return postGetUserUpdatePasswordUrl(username);
+      return postGetUserUpdatePasswordUrl(email);
     },
     {
       onSuccess(data) {
@@ -37,7 +37,7 @@ const GetUpdatePasswordUrlMenuItem = ({ username }) => {
 };
 
 GetUpdatePasswordUrlMenuItem.propTypes = {
-  username: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
 };
 
 export default GetUpdatePasswordUrlMenuItem;

--- a/ui/src/pages/login/LoginForm.js
+++ b/ui/src/pages/login/LoginForm.js
@@ -5,18 +5,18 @@ import React from "react";
 import * as Yup from "yup";
 
 const formValidationSchema = Yup.object().shape({
-  username: Yup.string().required("Requis"),
+  email: Yup.string().required("Requis"),
   password: Yup.string().required("Requis"),
 });
 
 const LoginForm = ({ onSubmit }) => {
   return (
-    <Formik initialValues={{ username: "", password: "" }} validationSchema={formValidationSchema} onSubmit={onSubmit}>
+    <Formik initialValues={{ email: "", password: "" }} validationSchema={formValidationSchema} onSubmit={onSubmit}>
       {({ status = {} }) => {
         return (
           <Form>
             <Box marginBottom="2w">
-              <Field name="username">
+              <Field name="email">
                 {({ field, meta }) => (
                   <FormControl isRequired isInvalid={meta.error && meta.touched} marginBottom="2w">
                     <FormLabel color="grey.800">adresse email</FormLabel>


### PR DESCRIPTION
Suppression du champ username qui n'est pas utile car on utilise l'email partout (vu coté métier)

Dépends de https://github.com/mission-apprentissage/partage-simplifie/pull/27